### PR TITLE
Test kv get after put

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 url = "2.1"
 
 [dev-dependencies]
+base64 = "0.13"
 hostname = "0.3"
 rand = "0.8.3"
 rstest = "0.8.0"

--- a/tests/kv.rs
+++ b/tests/kv.rs
@@ -18,6 +18,10 @@ fn kv_test() {
 
     assert!(client.put(&pair, None).unwrap().0);
 
+    let b64val = client.get("testkey", None).unwrap().0.unwrap().Value;
+    let bytes = base64::decode(b64val).unwrap();
+    assert_eq!(std::str::from_utf8(&bytes).unwrap(), "\"testvalue\"");
+
     let r = client.list("t", None).unwrap();
     assert!(!r.0.is_empty());
 


### PR DESCRIPTION
The test added here is broken:
```
running 1 test
test kv_test ... FAILED

failures:

---- kv_test stdout ----
thread 'kv_test' panicked at 'assertion failed: `(left == right)`
  left: `"\"testvalue\""`,
 right: `"testvalue"`', tests/kv.rs:23:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```