### PR TITLE
Add ClientBuilder::new_from_consul_host()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,23 @@ impl Config {
                 wait_time: None,
             })
     }
+
+    pub fn new_from_consul_host(
+        host: &str,
+        port: Option<u16>,
+        token: Option<String>,
+    ) -> Result<Config> {
+        ClientBuilder::new()
+            .build()
+            .chain_err(|| "Failed to build reqwest client")
+            .map(|client| Config {
+                address: format!("{}:{}", host, port.unwrap_or(8500)),
+                datacenter: None,
+                http_client: client,
+                token,
+                wait_time: None,
+            })
+    }
 }
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
I needed this functionality, since in my use case there's an env-var which contains only host name (e.g. `172.17.0.1`) without specifying the port. Also, I read the env-var and default to a different value than `127.0.0.1`.