### PR TITLE
Set clippy to run on all targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,4 +77,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-targets --all-features -- -D warnings


### PR DESCRIPTION
Run clippy on all targets, to cover test code.
Done according to instructions at [1]

[1] https://github.com/rust-lang/rust-clippy#travis-ci