### PR TITLE
Fix putting extra quotes on kv values.

### DIFF
--- a/src/kv.rs
+++ b/src/kv.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::errors::Error;
 use crate::errors::Result;
-use crate::request::{delete, get, get_vec, put};
+use crate::request::{delete, get, get_vec, put, put_body};
 use crate::{Client, QueryMeta, QueryOptions, WriteMeta, WriteOptions};
 
 #[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize, Debug)]
@@ -74,7 +74,7 @@ impl KV for Client {
             }
         }
         let path = format!("/v1/kv/{}", pair.Key);
-        put(&path, Some(&pair.Value), &self.config, params, o)
+        put_body(&path, Some(pair.Value.clone()), &self.config, params, o)
     }
 
     fn release(&self, pair: &KVPair, o: Option<&WriteOptions>) -> Result<(bool, WriteMeta)> {

--- a/tests/kv.rs
+++ b/tests/kv.rs
@@ -20,7 +20,7 @@ fn kv_test() {
 
     let b64val = client.get("testkey", None).unwrap().0.unwrap().Value;
     let bytes = base64::decode(b64val).unwrap();
-    assert_eq!(std::str::from_utf8(&bytes).unwrap(), "\"testvalue\"");
+    assert_eq!(std::str::from_utf8(&bytes).unwrap(), "testvalue");
 
     let r = client.list("t", None).unwrap();
     assert!(!r.0.is_empty());


### PR DESCRIPTION
Values stored using the KV API are currently serialized as json when they are already strings, this causes them to be put in quotes(#49). This pr adds 2 new methods to request.rs to send a put request with the body as bytes which is what consul is expecting.