### PR TITLE
Added status API calls (leader, peers) and node service health checks, changed tag filtering

### DIFF
--- a/src/health.rs
+++ b/src/health.rs
@@ -48,6 +48,15 @@ pub trait Health {
         passing_only: bool,
         options: Option<&QueryOptions>,
     ) -> Result<(Vec<ServiceEntry>, QueryMeta)>;
+
+    fn node(
+        &self,
+        node: &str,
+        service_name: Option<&str>,
+        check_id: Option<&str>,
+        tag: Option<&str>,
+        options: Option<&QueryOptions>,
+    ) -> Result<(Vec<HealthCheck>, QueryMeta)>;
 }
 
 impl Health for Client {
@@ -58,14 +67,57 @@ impl Health for Client {
         passing_only: bool,
         options: Option<&QueryOptions>,
     ) -> Result<(Vec<ServiceEntry>, QueryMeta)> {
+        let mut qoptions = options.map_or_else(QueryOptions::default, |qo| qo.to_owned());
         let mut params = HashMap::new();
         let path = format!("/v1/health/service/{}", service);
         if passing_only {
             params.insert(String::from("passing"), String::from("1"));
         }
         if let Some(tag) = tag {
-            params.insert(String::from("tag"), tag.to_owned());
+            let mut filter = qoptions.filter.unwrap_or_default();
+            if !filter.is_empty() {
+                filter = format!("({filter}) and ");
+            }
+            filter.push_str(&format!("\"{tag}\" in Service.Tags"));
+            qoptions.filter = Some(filter);
         }
-        get(&path, &self.config, params, options)
+        get(&path, &self.config, params, Some(&qoptions))
+    }
+
+    fn node(
+        &self,
+        node: &str,
+        check_id: Option<&str>,
+        service_name: Option<&str>,
+        tag: Option<&str>,
+        options: Option<&QueryOptions>,
+    ) -> Result<(Vec<HealthCheck>, QueryMeta)> {
+        let mut qoptions = options.map_or_else(QueryOptions::default, |qo| qo.to_owned());
+        let params = HashMap::new();
+        let path = format!("/v1/health/node/{}", node);
+        if let Some(service_name) = service_name {
+            let mut filter = qoptions.filter.unwrap_or_default();
+            if !filter.is_empty() {
+                filter = format!("({filter}) and ");
+            }
+            filter.push_str(&format!("ServiceName == \"{service_name}\""));
+            qoptions.filter = Some(filter);
+        } else if let Some(check_id) = check_id {
+            let mut filter = qoptions.filter.unwrap_or_default();
+            if !filter.is_empty() {
+                filter = format!("({filter}) and ");
+            }
+            filter.push_str(&format!("CheckID == \"{check_id}\""));
+            qoptions.filter = Some(filter);
+        }
+        if let Some(tag) = tag {
+            let mut filter = qoptions.filter.unwrap_or_default();
+            if !filter.is_empty() {
+                filter = format!("({filter}) and ");
+            }
+            filter.push_str(&format!("\"{tag}\" in ServiceTags"));
+            qoptions.filter = Some(filter);
+        }
+        get(&path, &self.config, params, Some(&qoptions))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod errors;
 pub mod health;
 pub mod kv;
 pub mod session;
+pub mod status;
 
 mod request;
 
@@ -104,6 +105,7 @@ impl Config {
 #[derive(Clone, Debug, Default)]
 pub struct QueryOptions {
     pub datacenter: Option<String>,
+    pub filter: Option<String>,
     pub wait_index: Option<u64>,
     pub wait_time: Option<Duration>,
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -30,7 +30,7 @@ pub fn get_vec<R: DeserializeOwned>(
 ) -> Result<(Vec<R>, QueryMeta)> {
     let datacenter: Option<&String> = options
         .and_then(|o| o.datacenter.as_ref())
-        .or_else(|| config.datacenter.as_ref());
+        .or(config.datacenter.as_ref());
 
     if let Some(dc) = datacenter {
         params.insert(String::from("dc"), dc.to_owned());
@@ -48,7 +48,7 @@ pub fn get_vec<R: DeserializeOwned>(
     let url =
         Url::parse_with_params(&url_str, params.iter()).chain_err(|| "Failed to parse URL")?;
     let start = Instant::now();
-    let request_builder = add_config_options(config.http_client.get(url), &config);
+    let request_builder = add_config_options(config.http_client.get(url), config);
     let response = request_builder.send();
     response
         .chain_err(|| "HTTP request to consul failed")
@@ -94,7 +94,7 @@ pub fn get<R: DeserializeOwned>(
 ) -> Result<(R, QueryMeta)> {
     let datacenter: Option<&String> = options
         .and_then(|o| o.datacenter.as_ref())
-        .or_else(|| config.datacenter.as_ref());
+        .or(config.datacenter.as_ref());
 
     if let Some(dc) = datacenter {
         params.insert(String::from("dc"), dc.to_owned());
@@ -106,13 +106,16 @@ pub fn get<R: DeserializeOwned>(
         if let Some(wait_time) = options.wait_time {
             params.insert(String::from("wait"), format!("{}s", wait_time.as_secs()));
         }
+        if let Some(filter) = &options.filter {
+            params.insert(String::from("filter"), filter.to_owned());
+        }
     }
 
     let url_str = format!("{}{}", config.address, path);
     let url =
         Url::parse_with_params(&url_str, params.iter()).chain_err(|| "Failed to parse URL")?;
     let start = Instant::now();
-    let request_builder = add_config_options(config.http_client.get(url), &config);
+    let request_builder = add_config_options(config.http_client.get(url), config);
     let response = request_builder.send();
     response
         .chain_err(|| "HTTP request to consul failed")
@@ -191,7 +194,7 @@ where
     let start = Instant::now();
     let datacenter: Option<&String> = options
         .and_then(|o| o.datacenter.as_ref())
-        .or_else(|| config.datacenter.as_ref());
+        .or(config.datacenter.as_ref());
 
     if let Some(dc) = datacenter {
         params.insert(String::from("dc"), dc.to_owned());
@@ -206,7 +209,7 @@ where
     } else {
         builder
     };
-    let builder = add_config_options(builder, &config);
+    let builder = add_config_options(builder, config);
     builder
         .send()
         .chain_err(|| "HTTP request to consul failed")

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,23 @@
+use std::collections::HashMap;
+
+use crate::errors::Result;
+use crate::request::get;
+use crate::{Client, QueryMeta, QueryOptions};
+
+pub type Peer = String;
+
+pub trait Status {
+    fn leader(&self, q: Option<&QueryOptions>) -> Result<(Peer, QueryMeta)>;
+    fn peers(&self, q: Option<&QueryOptions>) -> Result<(Vec<Peer>, QueryMeta)>;
+}
+
+impl Status for Client {
+    /// https://developer.hashicorp.com/consul/api-docs/status
+    fn leader(&self, q: Option<&QueryOptions>) -> Result<(Peer, QueryMeta)> {
+        get("/v1/status/leader", &self.config, HashMap::new(), q)
+    }
+
+    fn peers(&self, q: Option<&QueryOptions>) -> Result<(Vec<Peer>, QueryMeta)> {
+        get("/v1/status/peers", &self.config, HashMap::new(), q)
+    }
+}

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -25,3 +25,61 @@ fn health_test() {
         assert!(meta.last_index.unwrap() > 0, "index must be positive");
     }
 }
+#[test]
+fn health_node_test() {
+    use consul::health::Health;
+    let config = Config::new().unwrap();
+    let client = Client::new(config);
+    let system_hostname = hostname::get().unwrap().into_string().unwrap();
+    // An existing service for a agent in dev mode
+    let r = client
+        .node(&system_hostname, Some("serfHealth"), None, None, None)
+        .unwrap();
+    let (services, meta) = (r.0, r.1);
+    {
+        assert!(
+            !services.is_empty(),
+            "should have at least one Service Node"
+        );
+        assert!(meta.last_index.unwrap() > 0, "index must be positive");
+    }
+    // A non existing node, should be empty
+    let r = client
+        .node("non-existing-node", Some("serfHealth"), None, None, None)
+        .unwrap();
+    let (services, meta) = (r.0, r.1);
+    {
+        assert_eq!(services.len(), 0);
+        assert!(meta.last_index.unwrap() > 0, "index must be positive");
+    }
+    // A non existing check, should be empty
+    let r = client
+        .node(
+            &system_hostname,
+            Some("non-existing-check"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    let (services, meta) = (r.0, r.1);
+    {
+        assert_eq!(services.len(), 0);
+        assert!(meta.last_index.unwrap() > 0, "index must be positive");
+    }
+    // A non existing service, should be empty
+    let r = client
+        .node(
+            &system_hostname,
+            None,
+            Some("non-existing-service"),
+            None,
+            None,
+        )
+        .unwrap();
+    let (services, meta) = (r.0, r.1);
+    {
+        assert_eq!(services.len(), 0);
+        assert!(meta.last_index.unwrap() > 0, "index must be positive");
+    }
+}

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -149,12 +149,12 @@ fn session_node_test() {
 
     let (session_entries, _) = client.node(&system_hostname, None).unwrap();
 
-    let filtered_session_entries: Vec<&SessionEntry> = session_entries
+    let filtered_session_entries_count = session_entries
         .iter()
         .filter(|s| s.Name.as_ref().unwrap() == &unique_test_identifier)
-        .collect();
+        .count();
 
-    assert_eq!(filtered_session_entries.len(), 1);
+    assert_eq!(filtered_session_entries_count, 1);
 
     tear_down(&client, &created_session_entry_id);
 }
@@ -200,10 +200,8 @@ fn get_number_of_session_entries_with_matching_name(
 ) -> usize {
     let (session_entries, _) = client.list(None).unwrap();
 
-    let filtered_session_entries: Vec<&SessionEntry> = session_entries
+    session_entries
         .iter()
         .filter(|s| s.Name.as_ref().unwrap() == unique_test_identifier)
-        .collect();
-
-    filtered_session_entries.len()
+        .count()
 }

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -1,0 +1,30 @@
+extern crate consul;
+use consul::status::Status;
+use consul::{Client, Config};
+
+#[test]
+fn status_leader_test() {
+    let config = Config::new().unwrap();
+    let client = Client::new(config);
+    // An existing service for a agent in dev mode
+    let r = client.leader(None).unwrap();
+
+    let (peer, _meta) = r;
+    {
+        assert_eq!(peer, "127.0.0.1:8300");
+    }
+}
+
+#[test]
+fn status_peers_test() {
+    let config = Config::new().unwrap();
+    let client = Client::new(config);
+    // An existing service for a agent in dev mode
+    let r = client.peers(None).unwrap();
+
+    let (peers, _meta) = r;
+    {
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0], "127.0.0.1:8300");
+    }
+}


### PR DESCRIPTION
Hello,

I've added status API calls (https://developer.hashicorp.com/consul/api-docs/status) to check cluster status, changed the tag filtering method (use *filter* query parameter instead of *tag*, **added *filter* variable in QueryOptions**) and added node health check API calls (https://developer.hashicorp.com/consul/api-docs/health#list-checks-for-node).

Thanks,

Emilien